### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Intro
 
-This is a [rocker](https://github.com/tfoote/rocker) extension for adding [cargo](https://github.com/jesseduffield/cargo) to an existing docker image.  Check out the [rocker](https://github.com/osrf/rocker) GitHub page for more details on how Rocker and its extensions work. In short, Rocker allows you to add custom capabilities to existing Docker containers.
+This is a [rocker](https://github.com/tfoote/rocker) extension for adding [cargo](https://github.com/rust-lang/cargo) to an existing docker image.  Check out the [rocker](https://github.com/osrf/rocker) GitHub page for more details on how Rocker and its extensions work. In short, Rocker allows you to add custom capabilities to existing Docker containers.
 
 ## Installation
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the hyperlink for 'cargo' in the README.md to point to the official Rust Cargo repository.